### PR TITLE
ルーティングの修正

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -34,6 +34,11 @@ class GroupsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
+
+  def show
+    @group = Group.find(params[:id])
+    @events = @group.events
+  end
   private
 
   def group_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,22 @@
 Rails.application.routes.draw do
   resources :events
-  resources :groups
-  devise_for :users, controllers: {
-    registrations: 'users/registrations',
+  resources :groups do
+    resources :events
+  end
 
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
   }
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   root "tops#index"
   namespace :users do
     resource :invitations, only: %i[show create]
   end
+
+  resources :users do
+    resources :events, only: [:index]
+  end
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
- userのマイページ、groupのページでカレンダーにイベント一覧が取得表示できるようにルーティングを修正しました。
- view検証のために`resources :events`を残しています。