### PR TITLE
日付ごとのイベント一覧画面実装とその他周辺機能実装

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -5,7 +5,8 @@ class EventsController < ApplicationController
   end
 
   def new
-    @event = Event.new
+    @group = Group.find(params[:group_id])
+    @event = @group.events.build
   end
 
   def show
@@ -13,8 +14,14 @@ class EventsController < ApplicationController
   end
 
   def create
-    Event.create(event_parameter)
-    redirect_to events_path
+    @group = Group.find(params[:event][:group_id])
+    @event = @group.events.build(event_parameter)
+
+    if @event.save
+      redirect_to group_events_path(@group, @event), notice: 'イベントを作成しました。'
+    else
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def destroy
@@ -36,9 +43,15 @@ class EventsController < ApplicationController
     end
   end
 
+  def daily_schedule
+    @date = Date.parse(params[:date])
+    @group = Group.find(params[:group_id])
+    @events = @group.events.where('DATE(start_time) = ?', @date)
+  end
+
   private
 
   def event_parameter
-    params.require(:event).permit(:title, :start_datetime, :end_datetime)
+    params.require(:event).permit(:title, :start_time, :end_time, :description, :group_id)
   end
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,5 +1,6 @@
 <%= form_with(model: @event, local: true) do |f| %>
 
+  <%= f.hidden_field :group_id, value: @group.id %>
   <div class="title">
     <%= f.label :title %>
     <%= f.text_field :title %>
@@ -7,12 +8,12 @@
 
   <div class="time">
     <%= f.label :start_time %>
-    <%= f.datetime_field :start_datetime %>
+    <%= f.datetime_field :start_time %>
   </div>
 
   <div class="time">
     <%= f.label :end_time %>
-    <%= f.datetime_field :end_datetime %>
+    <%= f.datetime_field :end_time %>
   </div>
 
   <div class="description">

--- a/app/views/events/daily_schedule.html.erb
+++ b/app/views/events/daily_schedule.html.erb
@@ -1,0 +1,24 @@
+<div class="container">
+  <h1 class="text-3xl font-bold"><%= @group.title %></h1>
+  <p><%= @date.strftime('%Y-%m-%d') %></p>
+  <p>予定一覧</p>
+  <!-- イベント追加ボタン -->
+  <div class="add-event-button">
+    <%= link_to new_group_event_path(group_id: @group.id), class: "add-event-link" do %>
+      <i class="fas fa-plus"></i>
+    <% end %>
+  </div>
+  <ul>
+    <% @events.each do |event| %>
+      <li>
+        <%= event.start_time.strftime('%H:%M') %> ~ <%= event.end_time.strftime('%H:%M') %>:
+        <%= link_to event.title, event %>
+        <%= link_to '<i class="fas fa-trash"></i>'.html_safe, event, data: { "turbo-method": :delete }, data: { confirm: 'このイベントを削除してよろしいですか？' }, class: "text-red-500" %>
+      </li>
+    <% end %>
+  </ul>
+
+  <div class="mt-4">
+    <%= link_to 'カレンダーに戻る', group_events_path(group_id: @group.id), class: "btn btn-primary" %>
+  </div>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -7,11 +7,11 @@
 <%= link_to t('events.new.title'), new_event_path %>
 <%= turbo_frame_tag 'calendar' do %>
   <%= month_calendar events: @events do |date, events| %>
-    <%= link_to date.day, "#", class:"inline-flex w-6 h-6 items-center justify-center cursor-pointer text-center leading-none rounded-full transition ease-in-out duration-100 hover:bg-blue-200" %>
+    <%= link_to date.day, daily_schedule_events_path(date: date, group_id: @group.id), class:"inline-flex w-6 h-6 items-center justify-center cursor-pointer text-center leading-none rounded-full transition ease-in-out duration-100 hover:bg-blue-200", data: { turbo_frame: '_top' } %>
 
     <% events.each do |event| %>
       <div class="px-2 py-1 rounded-lg mt-1 overflow-hidden border border-blue-200 text-blue-800 bg-blue-100">
-        <%= link_to event.title, event, class:"text-sm truncate leading-tight" %>
+        <%= link_to event.title, event_path(event), class:"text-sm truncate leading-tight", data: { turbo_frame: '_top' } %>
       </div>
     <% end %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  resources :events
+  resources :events do
+    get 'daily_schedule', on: :collection
+  end
   resources :groups do
     resources :events
   end


### PR DESCRIPTION
見た目整えられてないけど、一旦機能実装完了しました。
[![Image from Gyazo](https://i.gyazo.com/a20038e21af5c1c189925d6b4638b92f.png)](https://gyazo.com/a20038e21af5c1c189925d6b4638b92f)

- [x] イベント作成時にグループと関連付けられるように実装
- [x] イベント作成後にグループの一覧画面へ戻るように実装
- [x] イベント一覧のイベントタイトルクリックでイベントの詳細画面に飛ぶように実装
- [x] イベント一覧の日付を押したらその日のイベント一覧へ飛ぶように実装。
- [x] 日付ごとのイベント一覧ページにイベント追加ボタン、イベント削除ボタン、カレンダーに戻るボタン実装
