### PR TITLE
日付ごとのイベント一覧画面の見た目を整える

### DIFF
--- a/app/views/events/daily_schedule.html.erb
+++ b/app/views/events/daily_schedule.html.erb
@@ -1,24 +1,37 @@
-<div class="container">
+<div class="container mx-auto mt-8">
   <h1 class="text-3xl font-bold"><%= @group.title %></h1>
-  <p><%= @date.strftime('%Y-%m-%d') %></p>
-  <p>予定一覧</p>
+
   <!-- イベント追加ボタン -->
-  <div class="add-event-button">
-    <%= link_to new_group_event_path(group_id: @group.id), class: "add-event-link" do %>
+  <div class="text-right">
+    <%= link_to new_group_event_path(group_id: @group.id), class: "button-add-event rounded-none bg-lemon-100 bg-yellow-100 px-8 py-6" do %>
       <i class="fas fa-plus"></i>
     <% end %>
   </div>
-  <ul>
-    <% @events.each do |event| %>
-      <li>
-        <%= event.start_time.strftime('%H:%M') %> ~ <%= event.end_time.strftime('%H:%M') %>:
-        <%= link_to event.title, event %>
-        <%= link_to '<i class="fas fa-trash"></i>'.html_safe, event, data: { "turbo-method": :delete }, data: { confirm: 'このイベントを削除してよろしいですか？' }, class: "text-red-500" %>
-      </li>
-    <% end %>
-  </ul>
+
+  <div class="event-date-header text-2xl font-semibold mt-5 mb-3">
+    <p><%= @date.strftime('%Y-%m-%d') %></p>
+    <p>予定一覧</p>
+  </div>
+
+  <div class="event-list mb-5 px-5">
+    <ul>
+      <% @events.each do |event| %>
+        <li class="event-item bg-cyan-100 rounded-lg p-2 text-gray-600 mb-4">
+          <div class="flex items-center justify-between">
+            <div>
+              <%= event.start_time.strftime('%H:%M') %> ~ <%= event.end_time.strftime('%H:%M') %>:
+              <%= link_to event.title, event %>
+            </div>
+            <%= link_to event_path(event), method: :delete, data: { confirm: 'このイベントを削除してよろしいですか？' }, class: "btn-delete-event rounded-lg drop-shadow-lg bg-yellow-100 hover:bg-yellow-300 hover:drop-shadow-none px-2 py-2" do %>
+              <i class="fas fa-trash"></i>
+            <% end %>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  </div>
 
   <div class="mt-4">
-    <%= link_to 'カレンダーに戻る', group_events_path(group_id: @group.id), class: "btn btn-primary" %>
+    <%= link_to 'カレンダーに戻る', group_events_path(group_id: @group.id), class: "back-to-calendar rounded-lg drop-shadow-lg bg-yellow-100 hover:bg-yellow-300 hover:drop-shadow-none px-2 py-2" %>
   </div>
 </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -25,7 +25,7 @@
             <p class="bg-cyan-100 rounded-lg p-2 text-gray-600"><%= user.introduction %></p>
           </div>
           <!-- ユーザー削除ボタン -->
-          <%= link_to '#', method: :delete, data: { confirm: 'ユーザーを削除しますか？' }, class: "rounded-lg drop-shadow-lg bg-yellow-100 hover:bg-yellow-300 hover:drop-shadow-none px-2 py-2" do %>
+          <%= link_to '#', data: { "turbo-method": :delete }, data: { confirm: 'ユーザーを削除しますか？' }, class: "rounded-lg drop-shadow-lg bg-yellow-100 hover:bg-yellow-300 hover:drop-shadow-none px-2 py-2" do %>
             <i class="fas fa-trash"></i>
           <% end %>
         </div>


### PR DESCRIPTION
[![Image from Gyazo](https://i.gyazo.com/95ac719175461cec2ebc4bbf07e5aade.png)](https://gyazo.com/95ac719175461cec2ebc4bbf07e5aade)
見た目を整えました。
イベント削除ボタンが機能してないのでそこを直す必要がありますが、とりあえずこまめにプッシュします。