### PR TITLE
日付ごとのイベント一覧画面完成

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,6 +8,7 @@ class EventsController < ApplicationController
 
   def new
     @event = @group.events.build
+    @event.start_time = DateTime.parse(params[:date])
   end
 
   def show
@@ -46,8 +47,12 @@ class EventsController < ApplicationController
   end
 
   def daily_schedule
-    @date = Date.parse(params[:date])
-    @events = @group.events.where('DATE(start_time) = ?', @date)
+    @date = params[:date].to_date
+    @group = Group.find(params[:group_id])
+  
+    # この日付がイベントの開始日または終了日の範囲内にあるイベントを取得
+    @events = Event.where('start_time <= ? AND end_time >= ?', @date.end_of_day, @date.beginning_of_day)
+                   .where(group_id: @group.id)
   end
 
   private

--- a/app/views/events/daily_schedule.html.erb
+++ b/app/views/events/daily_schedule.html.erb
@@ -3,32 +3,48 @@
 
   <!-- イベント追加ボタン -->
   <div class="text-right">
-    <%= link_to new_group_event_path(group_id: @group.id), class: "button-add-event rounded-none bg-lemon-100 bg-yellow-100 px-8 py-6" do %>
+    <%= link_to new_group_event_path(group_id: @group.id, date: @date), class: "button-add-event rounded-none bg-lemon-100 bg-yellow-100 px-8 py-6" do %>
       <i class="fas fa-plus"></i>
     <% end %>
   </div>
 
   <div class="event-date-header text-2xl font-semibold mt-5 mb-3">
-    <p><%= @date.strftime('%Y-%m-%d') %></p>
+    <p><%= @date.strftime('%Y年%m月%d日') %></p>
     <p>予定一覧</p>
   </div>
 
   <div class="event-list mb-5 px-5">
-    <ul>
-      <% @events.each do |event| %>
-        <li class="event-item bg-cyan-100 rounded-lg p-2 text-gray-600 mb-4">
-          <div class="flex items-center justify-between">
-            <div>
-              <%= event.start_time.strftime('%H:%M') %> ~ <%= event.end_time.strftime('%H:%M') %>:
-              <%= link_to event.title, event %>
+    <% if @events.empty? %>
+      <p>イベントはありません。</p>
+    <% else %>
+      <ul>
+        <% @events.each do |event| %>
+          <li class="event-item my-2">
+            <div class="flex justify-between items-center">
+              <div class="event-details bg-cyan-100 rounded-lg p-2 text-gray-600 w-full mr-5">
+                <div class="event-time font-semibold">
+                  <% if event.start_time.to_date == event.end_time.to_date %>
+                    <%= event.start_time.strftime('%H:%M') %> ~ <%= event.end_time.strftime('%H:%M') %>
+                  <% else %>
+                    <%= event.start_time.strftime('%m月%d日 %H:%M') %> ~ <%= event.end_time.strftime('%m月%d日 %H:%M') %>
+                  <% end %>
+                </div>
+                <div class="event-title font-semibold">
+                  タイトル: <%= link_to event.title, event %>
+                </div>
+                <div class="event-description font-semibold">
+                  内容: <%= event.description %>
+                </div>
+              </div>
+              <%= link_to event_path(event, group_id: @group.id), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') }, class: "btn-delete-event rounded-lg drop-shadow-lg bg-yellow-100 hover:bg-yellow-300 hover:drop-shadow-none px-2 py-2" do %>
+                <i class="fas fa-trash"></i>
+              <% end %>
             </div>
-            <%= link_to event_path(event), method: :delete, data: { confirm: 'このイベントを削除してよろしいですか？' }, class: "btn-delete-event rounded-lg drop-shadow-lg bg-yellow-100 hover:bg-yellow-300 hover:drop-shadow-none px-2 py-2" do %>
-              <i class="fas fa-trash"></i>
-            <% end %>
-          </div>
-        </li>
-      <% end %>
-    </ul>
+          </li>
+        <% end %>
+
+      </ul>
+    <% end %>
   </div>
 
   <div class="mt-4">


### PR DESCRIPTION
- [x] イベントが二日にわたっている場合、開始日の日付には表示があるが終了日の日付のイベント一覧には表示がないのでコントローラーを修正。
- [x] ゴミ箱ボタンを押したらイベント削除できるように変更。
- [x] 日付の表示方法をYYYY年MM月DD日に変更。複数日にイベントが渡る場合のみ日付ごとのイベント一覧に日付も記載。
- [x] 日付のイベント一覧画面からイベント追加するときに、その日の日付を初期値に設定
- [x] タイトル：内容：を追加。
- [x] ゴミ箱の背景無くす。

[![Image from Gyazo](https://i.gyazo.com/f4dc55effe135ac6dd958f5c3a3ed00a.png)](https://gyazo.com/f4dc55effe135ac6dd958f5c3a3ed00a)

