### PR TITLE
グループカレンダーのviewを修正

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -25,9 +25,11 @@
         <%= link_to date.day, daily_schedule_events_path(date: date, group_id: @group.id), class:"inline-flex w-6 h-6 items-center justify-center cursor-pointer text-center leading-none rounded-full transition ease-in-out duration-100 hover:bg-blue-200", data: { turbo_frame: '_top' } %>
           <div class="overflow-hidden">
             <% events.first(2).each do |event| %>
-                <div class="px-1 py-1 rounded-lg mt-1 overflow-auto border border-blue-100 text-blue-800 bg-blue-100">
-                  <%= link_to event.title, event_path(event, group_id: @group.id), class:"text-sm truncate leading-tight", data: { turbo_frame: '_top' } %>
-                </div>
+                <%= link_to event_path(event, group_id: @group.id), data: { turbo_frame: '_top' } do %>
+                  <div class="px-1 py-1 rounded-lg mt-1 overflow-auto border border-blue-100 text-blue-800 bg-blue-100">
+                    <p class="text-sm truncate leading-tight"><%= event.title %></p>
+                  </div>
+                <% end %>
             <% end %>
 
             <% if events.size > 2 %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,6 +1,11 @@
 <div class="antialiased bg-gray-100 w-full h-full">
   <div class="container px-6 mx-auto flex justify-between py-4">
-      <h3 class="text-lg font-semibold text-gray-600 l eading-6 lg:text-5xl"><font style="vertical-align: inherit;"><font style="vertical-align: inherit;"><%= @group.title %></font></font></h3>
+      <div class="flex space-x-3 text-gray-600">
+      <h3 class="text-lg font-semibold l eading-6 lg:text-5xl"><font style="vertical-align: inherit;"><font style="vertical-align: inherit;"><%= @group.title %></font></font></h3>
+        <%= link_to edit_group_path(@group), title: "グループ名変更" do %>
+          <i class="fa-solid fa-pencil" aria-hidden="true"></i>
+        <% end %>
+      </div>
     <div class="flex space-x-3 text-gray-600">
       <div class="flex flex-col">
         <%= link_to group_path(@group), class: "rounded-lg drop-shadow-lg bg-yellow-100 hover:bg-yellow-300 hover:drop-shadow-none px-4 py-3", title: "グループメンバー" do %>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,20 +1,10 @@
-<div class="flex items-center justify-center h-screen bg-gray-100">
-  <div class="bg-white py-6 rounded-md px-10 max-w-lg shadow-md ">
-    <h1 class="text-center text-lg font-bold text-gray-600">
-      グループ作成
-    </h1>
-    <p class="text-sm text-gray-500 text-center py-3">
-      グループ名を記入してください
-    </p>
-    <%= form_with(model: @group, local: true) do |f| %>
-        <div class="w-full">
-          <%= f.label :title, class: "sr-only" %>
-          <%= f.text_field :title, autofocus: true, id: "title", class: "block w-full px-5 py-3 text-base text-neutral-600 placeholder-gray-300 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
-        </div>
+<%= form_with(model: @group, local: true) do |f| %>
+    <div class="w-full">
+      <%= f.label :title, class: "sr-only" %>
+      <%= f.text_field :title, autofocus: true, id: "title", class: "block w-full px-5 py-3 text-base text-neutral-600 placeholder-gray-300 transition duration-500 ease-in-out transform border border-transparent rounded-lg bg-gray-50 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-300" %>
+    </div>
 
-        <div class="flex flex-col mt-4 lg:space-y-2">
-          <%= f.submit  class: "flex items-center justify-center w-full px-4 py-3 text-base font-medium text-center text-gray-600 transition duration-500 ease-in-out transform bg-yellow-100 rounded-xl hover:bg-yellow-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
-        </div>
-    <% end %>
-  </div>
-</div>
+    <div class="flex flex-col mt-4 lg:space-y-2">
+      <%= f.submit  class: "flex items-center justify-center w-full px-4 py-3 text-base font-medium text-center text-gray-600 transition duration-500 ease-in-out transform bg-yellow-100 rounded-xl hover:bg-yellow-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
+    </div>
+<% end %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,1 +1,13 @@
-<%= render "form" %>
+<div class="flex items-center justify-center h-screen bg-gray-100">
+  <div class="flex-col items-center justify-center">
+    <div class="bg-white py-6 rounded-md px-10 max-w-lg shadow-md ">
+      <h1 class="text-center text-lg font-bold text-gray-600 py-2">
+        <%= t('.title') %>
+      </h1>
+      <%= render "form" %>
+    </div>
+    <div class="text-center text-gray-500 py-2">
+    <%= link_to "back", group_events_path(@group), title: "戻る" %>
+    </div>
+  </div>
+</div>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,1 +1,11 @@
-<%= render "form" %>
+<div class="flex items-center justify-center h-screen bg-gray-100">
+  <div class="bg-white py-6 rounded-md px-10 max-w-lg shadow-md ">
+    <h1 class="text-center text-lg font-bold text-gray-600 py-2">
+      <%= t('.title') %>
+    </h1>
+    <p class="text-sm text-gray-500 text-center py-3">
+      グループ名を記入してください
+    </p>
+    <%= render "form" %>
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -34,6 +34,8 @@ ja:
   groups:
     new:
       title: グループ作成
+    edit:
+      title: グループ名変更
     error:
       blank_title: "グループ名を入力してください"
   simple_calendar:


### PR DESCRIPTION
- カレンダー内のイベントタイトルを囲む枠が、当月以外の日付はdisplay: none;にしてるけど表示されてしまっていため
aタグ内に枠のCSSを配置
- グループ名変更アイコンを追加