### PR TITLE
ユーザーの日別イベントの取得

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -15,6 +15,9 @@
   }
   .past a {
     color: gray;
+    p {
+      color: gray;
+    }
   }
   .day {
     height: 120px;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -12,9 +12,6 @@ class EventsController < ApplicationController
   # params[:date]が存在する場合のみDateTime.parseを使用
   if params[:date].present?
     @event.start_time = DateTime.parse(params[:date])
-  else
-    #現在の日時を設定
-    @event.start_time = DateTime.now
   end
 end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,4 +4,11 @@ class UsersController < ApplicationController
     @user = current_user
     @user_groups = @user.groups
   end
+
+  def events_for_date
+    @user = current_user
+    @user_groups = @user.groups
+    @selected_date = params[:date]&.to_date || Date.current
+    @events_for_selected_date = @user.events_for_calendar_by_date(@selected_date)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,4 +28,13 @@ class User < ApplicationRecord
     group_ids = self.groups.pluck(:id)
     Event.where(group_id: group_ids)
   end
+
+  def events_for_calendar_by_date(selected_date)
+    group_ids = self.groups.pluck(:id)
+    Event.where(group_id: group_ids)
+        .where('(start_time >= ? AND start_time <= ?) OR (end_time >= ? AND end_time <= ?)',
+                selected_date.beginning_of_day, selected_date.end_of_day,
+                selected_date.beginning_of_day, selected_date.end_of_day)
+        .order(:start_time)
+  end
 end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,7 +1,7 @@
 <div class="antialiased bg-gray-100 w-full h-full">
   <div class="container px-6 mx-auto flex justify-between py-4">
       <div class="flex space-x-3 text-gray-600">
-      <h3 class="text-lg font-semibold l eading-6 lg:text-5xl"><font style="vertical-align: inherit;"><font style="vertical-align: inherit;"><%= @group.title %></font></font></h3>
+      <h3 class="text-3xl font-semibold l eading-6 lg:text-5xl"><font style="vertical-align: inherit;"><font style="vertical-align: inherit;"><%= @group.title %></font></font></h3>
         <%= link_to edit_group_path(@group), title: "グループ名変更" do %>
           <i class="fa-solid fa-pencil" aria-hidden="true"></i>
         <% end %>

--- a/app/views/users/events_for_date.html.erb
+++ b/app/views/users/events_for_date.html.erb
@@ -1,0 +1,47 @@
+<div class="container mx-auto mt-8 text-gray-600">
+  <div class="event-date-header text-2xl font-semibold mt-5 mb-3">
+    <p><%= @selected_date.strftime("%Y年%m月%d日") %></p>
+    <p>予定一覧</p>
+  </div>
+
+  <div class="event-list mb-5 px-5">
+    <% if @events_for_selected_date.empty? %>
+      <p>イベントはありません。</p>
+    <% else %>
+      <%= turbo_frame_tag 'events_for_date' do %>
+        <ul>
+          <div class="overflow-hidden">
+            <% @events_for_selected_date.each do |event| %>
+              <li class="event-item my-2">
+                <div class="flex justify-between items-center">
+                  <div class="event-details bg-cyan-100 rounded-lg p-2 text-gray-600 w-full mr-5">
+                    <div class="event-time font-semibold">
+                      <% if event.start_time.to_date == event.end_time.to_date %>
+                        <%= event.start_time.strftime('%H:%M') %> ~ <%= event.end_time.strftime('%H:%M') %>
+                      <% else %>
+                        <%= event.start_time.strftime('%m月%d日 %H:%M') %> ~ <%= event.end_time.strftime('%m月%d日 %H:%M') %>
+                      <% end %>
+                    </div>
+                    <div class="event-title font-semibold">
+                      タイトル: <%= link_to event.title, event_path(event, group_id: event.group_id) %>
+                    </div>
+                    <div class="event-description font-semibold">
+                      内容: <%= event.description %>
+                    </div>
+                    <div class="event-group font-semibold">
+                      グループ:  <%= link_to group_events_path(group_id: event.group_id) do%><i class="fa-solid fa-users" aria-hidden="true"></i> <%= event.group.title %><% end %>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            <% end %>
+          </div>
+        </ul>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="mt-4">
+    <%= link_to "マイページに戻る", users_mypage_path, class: "back-to-calendar rounded-lg drop-shadow-lg bg-yellow-100 hover:bg-yellow-300 hover:drop-shadow-none px-2 py-2" %>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,9 +9,11 @@
         <%= link_to date.day, events_for_date_path(current_user, date: date), class:"inline-flex w-6 h-6 items-center justify-center cursor-pointer text-center leading-none rounded-full transition ease-in-out duration-100 hover:bg-blue-200", data: { turbo_frame: '_top' } %>
           <div class="overflow-hidden">
             <% events.first(2).each do |event| %>
-                <div class="px-1 py-1 rounded-lg mt-1 overflow-auto border border-blue-100 text-blue-800 bg-blue-100">
-                  <%= link_to event.title, event_path(event, group_id: event.group_id), class:"text-sm truncate leading-tight", data: { turbo_frame: '_top' } %>
-                </div>
+                <%= link_to event_path(event, group_id: event.group_id), data: { turbo_frame: '_top' } do %>
+                  <div class="px-1 py-1 rounded-lg mt-1 overflow-auto border border-blue-100 text-blue-800 bg-blue-100">
+                    <p class="text-sm truncate leading-tight"><%= event.title %></p>
+                  </div>
+                <% end %>
             <% end %>
 
             <% if events.size > 2 %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,7 @@
   <div>
     <%= turbo_frame_tag 'calendar' do %>
       <%= month_calendar events: current_user.events_for_calendar do |date, events| %>
-        <%= link_to date.day, "#", class:"inline-flex w-6 h-6 items-center justify-center cursor-pointer text-center leading-none rounded-full transition ease-in-out duration-100 hover:bg-blue-200", data: { turbo_frame: '_top' } %>
+        <%= link_to date.day, events_for_date_path(current_user, date: date), class:"inline-flex w-6 h-6 items-center justify-center cursor-pointer text-center leading-none rounded-full transition ease-in-out duration-100 hover:bg-blue-200", data: { turbo_frame: '_top' } %>
           <div class="overflow-hidden">
             <% events.first(2).each do |event| %>
                 <div class="px-1 py-1 rounded-lg mt-1 overflow-auto border border-blue-100 text-blue-800 bg-blue-100">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,6 @@
 <div class="antialiased bg-gray-100 w-full h-full">
   <div class="container px-6 mx-auto flex justify-between py-4">
-      <%= image_tag @user.profile_image.url, class: "rounded-full h-24 w-24" %>
+      <%= image_tag @user.profile_image.url, class: "rounded-full h-24 xg:h-48 w-24 lg:w-48" %>
       <h3 class="text-lg font-semibold text-gray-600 l eading-6 lg:text-5xl"><font style="vertical-align: inherit;"><font style="vertical-align: inherit;">Myカレンダー</font></font></h3>
   </div>
   <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     registrations: 'users/registrations',
   }
   get "users/mypage" => "users#show"
+  get "users/events_for_date", to: "users#events_for_date", as: :events_for_date
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   root "tops#index"
 


### PR DESCRIPTION
- マイページのカレンダー日付部分からその日のユーザーのイベントを取得できるよう実装
  - viewはグループカレンダーのものと同様な実装
 
- その他
  - グループページからのイベント作成時、start_timeの初期設定が秒単位でされていたので、グループページからのイベント作成時はstart_time設定をなしにした
  - ユーザーカレンダーCSSを微修正