### PR TITLE
不参加グループのイベント、チャット閲覧を制限

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -1,4 +1,5 @@
 class ChatsController < ApplicationController
+  include MembershipCheck
   before_action :authenticate_user!
 
   def index

--- a/app/controllers/concerns/membership_check.rb
+++ b/app/controllers/concerns/membership_check.rb
@@ -1,0 +1,17 @@
+module MembershipCheck
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :check_membership
+  end
+
+  private
+
+  def check_membership
+    @group = Group.find(params[:group_id])
+    unless @group.members.include?(current_user)
+      flash[:alert] = "グループに参加してください。"
+      redirect_to root_path
+    end
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,5 @@
 class EventsController < ApplicationController
+  include MembershipCheck
   before_action :authenticate_user!
   before_action :set_group
 


### PR DESCRIPTION
不参加グループのイベント、チャット閲覧を制限しました。
- controllers/concern/smembership_check.rbを作成
  - モジュール内にcheck_membershipメソッド定義
  - events_controller, chats_controllerでinclude