### PR TITLE
Chat layout

### DIFF
--- a/app/views/chats/_chat.html.erb
+++ b/app/views/chats/_chat.html.erb
@@ -7,7 +7,7 @@
         <% if chat.user.profile_image.present? %>
           <%= image_tag current_user.profile_image.url, class: "rounded-full h-24 w-24" %>
         <% else %>
-          <%= image_tag 'default.jpg', class: "rounded-full h-24 w-24" %>
+          <%= image_tag 'default.png', class: "rounded-full h-24 w-24" %>
         <% end %>
       </div>
     </div>

--- a/app/views/chats/_form.html.erb
+++ b/app/views/chats/_form.html.erb
@@ -1,8 +1,8 @@
-<div class="relative space-x-3 bg-secondary bg-opacity-50", id="new_chat">
+<div class="space-x-3 bg-secondary py-6 px-2" id="new_chat">
     <%= form_with(model: @chat, url: group_chats_path(@group), local: true) do |f|%>
     <div class="flex items-center">
-        <%= f.text_field :body, class: "input input-bordered input-base-100 block w-full h-10 rounded-full ", placeholder: "ここに入力"%>
-        <%= f.submit "投稿", class: "justify-center rounded-full border border-transparent bg-yellow-100 px-4 py-2 text-sm font-bold text-gray-600" do %>
+        <%= f.text_field :body, class: "input input-bordered input-base-100 block w-full h-10 rounded-full ", placeholder: "メッセージを入力"%>
+        <%= f.button type: 'submit', class: "justify-center rounded-full border border-transparent bg-primary px-4 py-2 text-sm font-bold text-secondary" do %>
           <i class="fa-solid fa-paper-plane fa-xl"></i>
         <% end %>
           <%= hidden_field_tag :user_id, current_user.id %>

--- a/app/views/chats/_form.html.erb
+++ b/app/views/chats/_form.html.erb
@@ -1,8 +1,8 @@
 <div class="relative space-x-3 bg-secondary bg-opacity-50", id="new_chat">
     <%= form_with(model: @chat, url: group_chats_path(@group), local: true) do |f|%>
     <div class="flex items-center">
-        <%= f.text_field :body, class: "input input-bordered input-base-100 block w-full h-10 rounded-md ", placeholder: "ここに入力"%>
-        <%= f.submit "投稿", class: "justify-center rounded-md border border-transparent bg-yellow-100 px-4 py-2 text-sm font-bold text-gray-600" do %>
+        <%= f.text_field :body, class: "input input-bordered input-base-100 block w-full h-10 rounded-full ", placeholder: "ここに入力"%>
+        <%= f.submit "投稿", class: "justify-center rounded-full border border-transparent bg-yellow-100 px-4 py-2 text-sm font-bold text-gray-600" do %>
           <i class="fa-solid fa-paper-plane fa-xl"></i>
         <% end %>
           <%= hidden_field_tag :user_id, current_user.id %>

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -9,13 +9,14 @@
         <%= turbo_stream_from @group %>
         <%= render @chats %>
       </turbo-frame>
-    <div>
-      <%= render partial: "form", locals: { group: @group, chat: @chat } %>
+    </div>
+    
 </div>
-
+<div class="ticky bottom-0 py-2" style="position: -webkit-sticky; position: sticky;">
+      <%= render partial: "form", locals: { group: @group, chat: @chat } %></div>
 <div>
  <%= link_to group_events_path(@group), class: "btn fixed bottom-36 right-12 rounded-full w-16 py-8 text-primary text-center" do %><i class="fa-solid fa-chevron-left fa-lg"></i><% end %>   
-    </div>
+</div>
 <script>
   function scrollToElement() {
     const scrollerInner = document.getElementById("scroller_inner");

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -14,6 +14,10 @@
     <div>
       <%= render partial: "form", locals: { group: @group, chat: @chat } %>
 </div>
+
+<div>
+ <%= link_to group_events_path(@group), class: "btn fixed bottom-36 right-12 rounded-full w-16 py-8 text-primary text-center" do %><i class="fa-solid fa-chevron-left fa-lg"></i><% end %>   
+    </div>
 <script>
   function scrollToElement() {
     const scrollerInner = document.getElementById("scroller_inner");

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -1,8 +1,6 @@
-<div class="navbar bg-secondary bg-opacity-50 text-gray-600">
+<div class="ticky top-0 navbar bg-secondary text-gray-600 z-10" style="position: -webkit-sticky; position: sticky;">
   <div class="btn btn-ghost text-xl">
-    <%= link_to group_events_path(@group) do%>
       <%= @group.title %>
-      <% end %>
     </div>
   </div>
 <div class="overflow-scroll">


### PR DESCRIPTION
- グループ名のバー画面追随の上部固定
- フォームも画面追随の下部固定
- 戻るボタン作成
[![Image from Gyazo](https://i.gyazo.com/5069d8b6a10909429b86d03adbe5c2f0.gif)](https://gyazo.com/5069d8b6a10909429b86d03adbe5c2f0)

一番下までスクロールすると戻るボタンとフォームが重なるのは明日修正します。
[![Image from Gyazo](https://i.gyazo.com/41981b6fc153e79cf770557d2910b492.gif)](https://gyazo.com/41981b6fc153e79cf770557d2910b492)