### PR TITLE
Fix calendar

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -4,13 +4,13 @@
   .prev-month a {
     display: none;
   }
-  .prev-month .label-style {
+  .prev-month .title-flame {
     display: none;
   }
   .next-month a {
     display: none;
   }
-  .next-month .label-style {
+  .next-month .title-flame {
     display: none;
   }
   .wday-0 .calendar-day {
@@ -47,11 +47,14 @@
   }
   .today a {
     background-color: #136988c0;
-    color: #f3f4f6;
     p {
       color: #4b5563;
     }
   }
+  .today .calendar-day{
+    color: #f3f4f6;
+    }
+
   .today a:hover{
     background-color: #bae6fd;
   }
@@ -69,10 +72,16 @@
     tr {
       font-size: x-small;
     }
-    .title-flame{
+    .title-flame {
       width: 30px;
       padding: 0.2px;
       p {
+        font-size: xx-small;
+      }
+    }
+    .more-event {
+      padding: 0.2px;
+      a {
         font-size: xx-small;
       }
     }

--- a/app/views/events/_show.html.erb
+++ b/app/views/events/_show.html.erb
@@ -6,6 +6,9 @@
         <p class="link link-primary"><%= @group.title %></p>
       <% end %>
     </div>
+    <div id="flash">
+      <%= render "shared/flash_message" %>
+    </div>
     <div class="space-y-5">
       <%= turbo_frame_tag dom_id(event) do %>
         <div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -48,27 +48,19 @@
   <div>
     <%= turbo_frame_tag 'calendar' do %>
       <%= month_calendar events: @events do |date, events| %>
-        <%= link_to date.day, daily_schedule_events_path(date: date, group_id: @group.id), class:"calendar-day inline-flex w-6 h-6 items-center justify-center cursor-pointer text-center leading-none rounded-full transition ease-in-out duration-100 hover:bg-sky-200 font-medium", data: { turbo_frame: '_top' } %>
+        <%= link_to date.day, daily_schedule_events_path(date: date, group_id: @group.id), class:"calendar-day inline-flex w-7 h-7 items-center justify-center cursor-pointer text-center leading-none rounded-full transition ease-in-out duration-100 hover:bg-sky-200 font-medium", data: { turbo_frame: '_top' } %>
           <div class="overflow-hidden">
             <% events.first(2).each do |event| %>
-              <label for="event_modal_<%= event.id %>" class="label-style">
-                <div class="title-flame px-1 py-1 rounded-lg mt-0.5 overflow-auto border border-sky-100 text-gray-600 bg-sky-100" >
-                  <p class="text-xs truncate leading-tight"><%= event.title %></p>
-                </div>
-              </label>
-
-              <input type="checkbox" id="event_modal_<%= event.id %>" class="modal-toggle" />
-              <div class="modal flex items-center justify-center" role="dialog">
-                <div class="modal-box">
-                  <%= render 'show', event: event, group_id: @group.id %>
-                </div>
-                <label class="modal-backdrop" for="event_modal_<%= event.id %>">Close</label>
-              </div>
+              <%= link_to daily_schedule_events_path(date: date, group_id: @group.id), data: { turbo_frame: '_top' } do %>
+                  <div class="title-flame px-1 py-1 rounded-lg mt-1 overflow-auto border border-sky-100 text-gray-600 bg-sky-100" >
+                    <p class="text-xs truncate leading-tight"><%= event.title %></p>
+                  </div>
+              <% end %>
             <% end %>
 
             <% if events.size > 2 %>
-              <div class="px-1 py-1 text-primary text-xs">
-                <%= link_to "+#{events.size - 2} more", daily_schedule_events_path(date: date, group_id: @group.id), class: "text-sm truncate leading-tight", data: { turbo_frame: '_top' } %>
+              <div class="more-event px-1 py-1 text-primary text-xs">
+                <%= link_to "+#{events.size - 2}", daily_schedule_events_path(date: date, group_id: @group.id), class: "text-sm truncate leading-tight", data: { turbo_frame: '_top' } %>
               </div>
             <% end %>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,14 +21,13 @@
       <%= render 'shared/before_login_header' %>
     <% end %>
 
-    <div id="flash">
-      <%= render "shared/flash_message" %>
-    </div>
+    <%= render "shared/flash_message" %>
+
     </header>
     <main class="flex-grow">
       <%= yield %>
     </main>
-    
+
     <footer class="mt-auto">
     <%= render 'shared/footer' %>
     </footer>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,10 +10,10 @@
   <div>
     <%= turbo_frame_tag 'calendar' do %>
       <%= month_calendar events: current_user.events_for_calendar do |date, events| %>
-        <%= link_to date.day, events_for_date_path(current_user, date: date), class:"calendar-day inline-flex w-6 h-6 items-center justify-center cursor-pointer text-center leading-none rounded-full transition ease-in-out duration-100 hover:bg-sky-200 font-medium", data: { turbo_frame: '_top' } %>
+        <%= link_to date.day, events_for_date_path(current_user, date: date), class:"calendar-day inline-flex w-7 h-7 items-center justify-center cursor-pointer text-center leading-none rounded-full transition ease-in-out duration-100 hover:bg-sky-200 font-medium", data: { turbo_frame: '_top' } %>
           <div class="overflow-hidden">
             <% events.first(2).each do |event| %>
-                <%= link_to group_events_path(group_id: event.group_id), data: { turbo_frame: '_top' } do %>
+                <%= link_to events_for_date_path(current_user, date: date), data: { turbo_frame: '_top' } do %>
                   <div class="title-flame px-1 py-1 rounded-lg mt-1 overflow-auto border border-sky-100 bg-sky-100">
                     <p class="text-xs truncate leading-tight"><%= event.title %></p>
                   </div>
@@ -21,8 +21,8 @@
             <% end %>
 
             <% if events.size > 2 %>
-              <div class="px-1 py-1 text-primary">
-                <%= link_to "+#{events.size - 2} more", events_for_date_path(current_user, date: date), class: "text-xs truncate leading-tight", data: { turbo_frame: '_top' } %>
+              <div class="more-event px-1 py-1 text-primary overflow-auto">
+                <%= link_to "+#{events.size - 2}", events_for_date_path(current_user, date: date), class: "text-xs truncate leading-tight", data: { turbo_frame: '_top' } %>
               </div>
             <% end %>
           </div>


### PR DESCRIPTION
- カレンダー枠をリンク元とするのが厳しかったので、日付でもイベントタイトルでもクリックしたら、日別の予定一覧に飛ぶようにしました
- カレンダー日付のhoverを大きくしました
- ２件以上の時"+⚪︎more"としているが、スマホサイズではどうしても幅を広げてしまうので"+:⚪︎"と変更しました

- イベント編集のフラッシュメッセージ（成功時）設定をしました
 [![Image from Gyazo](https://i.gyazo.com/7f7f60e5f5f997c1568455272293bc4e.png)](https://gyazo.com/7f7f60e5f5f997c1568455272293bc4e)