### PR TITLE
カレンダーcssの修正

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -46,12 +46,12 @@
     border-bottom-color: rgba(234, 232, 232, 0.857);
   }
   .today a {
-    background-color: #136988c0;
     p {
       color: #4b5563;
     }
   }
   .today .calendar-day{
+    background-color: #136988c0;
     color: #f3f4f6;
     }
 


### PR DESCRIPTION
【内容】
カレンダー内の日付がtodayかつイベントが２件以上ある場合の「+⚪︎件」部分のbackground-colorが設定されてしまっていたため無しに修正しました。

🔽修正前
[![Image from Gyazo](https://i.gyazo.com/ffaa25c8cc0985f8a7ff96865b32c850.png)](https://gyazo.com/ffaa25c8cc0985f8a7ff96865b32c850)

🔽修正後
[![Image from Gyazo](https://i.gyazo.com/ef3f76340562b195a89f172a14b92d62.png)](https://gyazo.com/ef3f76340562b195a89f172a14b92d62)